### PR TITLE
tooltips for color buttons and cleanup of main.css

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,12 +1,27 @@
+:root {
+    --fliese: #6c432b;
+    --banned: #444444;
+    --orange: #ee4d2e;
+    --schwuchtel: #ffffff;
+    --neuschwuchtel: #e208ea;
+    --pr0mium: #1cb992;
+    --altschwuchtel: #5bb91c;
+    --moderator: #008fff;
+    --admin: #ff9900;
+    --richtiges-grau: #161618;
+    --falsches-grau: #4f4f4f;
+    --text: #f2f5f4;
+}
+
 * {
     padding: 0;
     margin: 0;
 }
 
 body {
-    background-color: #161618;
+    background-color: var(--richtiges-grau);
     text-align: center;
-    color: #f2f5f4;
+    color: var(--text);
     font-family: sans-serif;
     font-size: 16px;
 }
@@ -20,7 +35,7 @@ body {
     position: absolute;
     top: 100px;
     left: 40%;
-    background-color: #161618;
+    background-color: var(--richtiges-grau);
     border: 1px solid #4f4f4f;
     padding: 1em;
     z-index: 10;
@@ -36,17 +51,16 @@ body {
 }
 
 #modalHelp a {
-    color: #ee4d2e;
+    color: var(--orange);
     text-decoration: none;
 }
 
 #closeHelp {
-    display: inline;
     float: right;
 }
 
 #closeHelp:hover {
-    color: #ee4d2e;
+    color: var(--orange);
     cursor: pointer;
 }
 
@@ -81,7 +95,7 @@ fieldset {
 }
 
 fieldset legend {
-    color: #ee4d2e;
+    color: var(--orange);
     padding: 0 .5em;
 }
 
@@ -90,7 +104,7 @@ p {
 }
 
 #content-output {
-    background-color: #4f4f4f;
+    background-color: var(--falsches-grau);
 }
 
 #pr0Canvas {
@@ -156,7 +170,7 @@ p {
 #div-image-info-size-cover-level .size-label {
     width: 40px;
     margin: auto;
-    background: #4f4f4f;
+    background: var(--falsches-grau);
     border-radius: 4px;
     padding: 2px;
     font-size: 11px;
@@ -167,7 +181,7 @@ p {
     height: 0;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
-    border-bottom: 5px solid #ffffff;
+    border-bottom: 5px solid #fff;
 }
 
 #imagetext {
@@ -195,14 +209,6 @@ p {
     display: block;
 }
 
-#hints b {
-
-}
-
-#edit-zone {
-
-}
-
 #edit-textarea {
     float:left;
 }
@@ -224,13 +230,13 @@ p {
 
 #controls {
     position: relative;
-    background-color: #161618;
+    background-color: var(--richtiges-grau);
 }
 
 .btn {
-    background: #161618 none repeat scroll 0 0;
+    background: var(--richtiges-grau) none repeat scroll 0 0;
     border: none;
-    color: #f2f5f4;
+    color: var(--text);
     font-weight: bold;
     margin: 5px 5px;
     text-decoration: none;
@@ -240,7 +246,7 @@ p {
 
 .btn:hover {
     cursor: pointer;
-    color: #ee4d2e;
+    color: var(--orange);
 }
 
 .btn:focus {
@@ -248,7 +254,7 @@ p {
 }
 
 .orange {
-    color: #ee4d2e;
+    color: var(--orange);
 }
 
 .red {
@@ -290,51 +296,78 @@ p {
     border: none;
 }
 
+.btn-colored-circle span {
+    display: none
+}
+
+.btn-colored-circle:hover {
+    position: relative;
+}
+
+.btn-colored-circle:hover span {
+    border: #464646 1px solid;
+    padding: 5px;
+    display: block;
+    z-index: 100;
+    background: var(--richtiges-grau);
+    left: 0px;
+    margin: 15px;
+    width: auto;
+    position: absolute;
+    top: 10px;
+    text-decoration: none
+}
+
 .btn-colored-circle:hover {
     cursor: pointer;
 }
 
 .btn-colored-circle.orange {
-    background-color: #ee4d2e;
+    background-color: var(--orange);
+    color: var(--orange);
 }
 
 .btn-colored-circle.pr0mium {
     /*Edler Spender, Lebende Legende*/
-    background-color: #1cb992;
+    background-color: var(--pr0mium);
+    color: var(--pr0mium);
 }
 
 .btn-colored-circle.neuschwuchtel {
-    background-color: #e208ea;
+    background-color: var(--neuschwuchtel);
+    color: var(--neuschwuchtel);
 }
 
 .btn-colored-circle.schwuchtel {
-    background-color: #ffffff;
+    background-color: var(--schwuchtel);
+    color: var(--schwuchtel);
 }
 
 .btn-colored-circle.altschwuchtel {
-    background-color: #5bb91c;
+    background-color: var(--altschwuchtel);
+    color: var(--altschwuchtel);
 }
 
 .btn-colored-circle.moderator {
-    background-color: #008fff;
+    background-color: var(--moderator);
+    color: var(--moderator);
 }
 
 .btn-colored-circle.admin {
-    background-color: #ff9900;
+    background-color: var(--admin);
+    color: var(--admin);
 }
 
 .btn-colored-circle.fliese {
-    background-color: #6c432b;
+    background-color: var(--fliese);
+    color: var(--fliese);
     width:15px;
     height:15px;
 }
 
 .btn-colored-circle.banned {
-    background-color: #444444;
+    background-color: var(--banned);
+    color: var(--banned);
     width:15px;
     height:15px;
-}
-
-#help {
-    /*cursor: not-allowed;*/
 }

--- a/css/main.css
+++ b/css/main.css
@@ -300,10 +300,6 @@ p {
     display: none
 }
 
-.btn-colored-circle:hover {
-    position: relative;
-}
-
 .btn-colored-circle:hover span {
     border: #464646 1px solid;
     padding: 5px;
@@ -320,6 +316,7 @@ p {
 
 .btn-colored-circle:hover {
     cursor: pointer;
+    position: relative;
 }
 
 .btn-colored-circle.orange {

--- a/html/index.html
+++ b/html/index.html
@@ -36,15 +36,15 @@
 
     <div id="controls">
         <div id="colorbuttons">
-            <button class="btn-colored-circle fliese"></button>
-            <button class="btn-colored-circle banned"></button>
-            <button class="btn-colored-circle orange"></button>
-            <button class="btn-colored-circle schwuchtel"></button>
-            <button class="btn-colored-circle neuschwuchtel"></button>
-            <button class="btn-colored-circle pr0mium"></button>
-            <button class="btn-colored-circle altschwuchtel"></button>
-            <button class="btn-colored-circle moderator"></button>
-            <button class="btn-colored-circle admin"></button>
+            <button class="btn-colored-circle fliese"><span>Fliese</span></button>
+            <button class="btn-colored-circle banned"><span>banned</span></button>
+            <button class="btn-colored-circle orange"><span>orange</span></button>
+            <button class="btn-colored-circle schwuchtel"><span>Schwuchtel</span></button>
+            <button class="btn-colored-circle neuschwuchtel"><span>Neuschwuchtel</span></button>
+            <button class="btn-colored-circle pr0mium"><span>pr0mium</span></button>
+            <button class="btn-colored-circle altschwuchtel"><span>Altschwuchtel</span></button>
+            <button class="btn-colored-circle moderator"><span>Moderator</span></button>
+            <button class="btn-colored-circle admin"><span>Admin</span></button>
         </div>
         <div id="extrabuttons">
             <input type="file" id="file-input" style="display: none;" />


### PR DESCRIPTION
### Tooltips
Tooltips für die Farb-Buttons eingefügt. 

Sieht dann so aus wenn man mit der Maus über einen Button fährt:

![tooltip](https://user-images.githubusercontent.com/5302085/46684630-b214d000-cbf3-11e8-87ff-5adf5e19be11.png)

### main.css
main.css aufgeräumt:
- Mehrfach benutzte Farben durch Variablen ersetzt.
- Leere css Selektorern gelöscht

### Tests

Manuell getestet in Firefox, Edge und Chrome.