### PR TITLE
alt-moderator farbe hinzugefügt

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -8,6 +8,7 @@
     --mittelaltschwuchtel: #addc8d;
     --altschwuchtel: #5bb91c;
     --moderator: #008fff;
+    --alt-moderator: #7fc7ff;
     --admin: #ff9900;
     --richtiges-grau: #161618;
     --falsches-grau: #4f4f4f;
@@ -186,7 +187,7 @@ p {
 }
 
 #imagetext {
-    width: 800px;
+    width: 850px;
     height: 23em;
     padding: 5px;
     background-color: #1B1E1F;
@@ -267,7 +268,7 @@ p {
 }
 
 #colorbuttons {
-    padding-top: 8px;
+    padding-top: 12px;
     float: left;
 }
 
@@ -291,7 +292,7 @@ p {
     vertical-align: bottom;
     width:25px;
     height:25px;
-    margin: 5px 5px;
+    margin: 3px;
     border-radius: 50%;
     background: #464646;
     border: none;
@@ -351,6 +352,11 @@ p {
     color: var(--moderator);
 }
 
+.btn-colored-circle.alt-moderator {
+    background-color: var(--alt-moderator);
+    color: var(--alt-moderator);
+}
+
 .btn-colored-circle.admin {
     background-color: var(--admin);
     color: var(--admin);
@@ -364,13 +370,9 @@ p {
 .btn-colored-circle.fliese {
     background-color: var(--fliese);
     color: var(--fliese);
-    width:15px;
-    height:15px;
 }
 
 .btn-colored-circle.banned {
     background-color: var(--banned);
     color: var(--banned);
-    width:15px;
-    height:15px;
 }

--- a/html/index.html
+++ b/html/index.html
@@ -44,6 +44,7 @@
             <button class="btn-colored-circle altschwuchtel"><span>Altschwuchtel</span></button>
             <button class="btn-colored-circle pr0mium"><span>pr0mium</span></button>
             <button class="btn-colored-circle moderator"><span>Moderator</span></button>
+            <button class="btn-colored-circle alt-moderator"><span>Alt-Moderator</span></button>
             <button class="btn-colored-circle admin"><span>Admin</span></button>
             <button class="btn-colored-circle orange"><span>orange</span></button>
         </div>
@@ -67,7 +68,7 @@
         </div>
     </div>
 
-    <div id="size">
+    <div class="clearfix" id="size">
         <fieldset>
             <legend>Bildgröße <a id="a-refresh-size" style="cursor: pointer;font-size: 11px;color:#008fff;">Aktualisieren</a></legend>
 

--- a/js/pr0p0st.js
+++ b/js/pr0p0st.js
@@ -124,7 +124,19 @@ $(function() {
     var textArea = $("#imagetext");
     var pr0Canvas = $("#pr0Canvas");
     var bcr = pr0Canvas[0].getBoundingClientRect();
-    var colors = {"c.fliese": "#6c432b", "c.banned": "#444444", "c.schwuchtel": "#ffffff", "c.orange": "#ee4d2e", "c.pr0mium": "#1cb992", "c.neu": "#e208ea", "c.alt": "#5bb91c", "c.mod": "#008fff", "c.admin": "#ff9900", "c.mittel": "#addc8d"};
+    var colors = {
+        "c.fliese": "#6c432b",
+        "c.banned": "#444444",
+        "c.schwuchtel": "#ffffff",
+        "c.orange": "#ee4d2e",
+        "c.pr0mium": "#1cb992",
+        "c.neu": "#e208ea",
+        "c.alt": "#5bb91c",
+        "c.mod": "#008fff",
+        "c.admin": "#ff9900",
+        "c.mittel": "#addc8d",
+        "c.alt-mod": "#7fc7ff",        
+    };
     var fonts = {"f.klein": "bold 14px 'Helvetica Neue', Helvetica, sans-serif", "f.normal": "bold 20px 'Helvetica Neue', Helvetica, sans-serif", "f.gross": "bold 60px 'Helvetica Neue', Helvetica, sans-serif"};
     var content = {"text": textArea.val(), "images": []};
     var draggingImage = -1;
@@ -494,6 +506,9 @@ $(function() {
     });
     $('.btn-colored-circle.moderator').on('click', function() {
         addTextAtCursor('${c.mod}');
+    });
+    $('.btn-colored-circle.alt-moderator').on('click', function() {
+        addTextAtCursor('${c.alt-mod}');
     });
     $('.btn-colored-circle.admin').on('click', function() {
         addTextAtCursor('${c.admin}');


### PR DESCRIPTION
- alt-moderator Farbe hinzugefügt
- Bildgrösse, Hinweise und Einstellungen rutschen nicht mehr nach oben, wenn Textfeld zu klein ist
- Alle Farb-Buttons gleich gross